### PR TITLE
Uses a more forgiving regexp to search when GEMNAME doesn't match exactly

### DIFF
--- a/lib/open_gem/common_options.rb
+++ b/lib/open_gem/common_options.rb
@@ -31,7 +31,7 @@ module OpenGem
       if specs.length == 0
         # If we have not tried to do a pattern match yet, fall back on it.
         if(!options[:exact] && !name.is_a?(Regexp))
-          pattern = /#{Regexp.escape name}/
+          pattern = /#{(Regexp.escape name).gsub(/\\-|_/, '(\\-|_|)')}/
           get_spec(pattern)
         else
           say "#{name.inspect} is not available"

--- a/test/common_options_test.rb
+++ b/test/common_options_test.rb
@@ -1,0 +1,56 @@
+require 'test/unit'
+require 'rubygems'
+require 'mocha'
+require 'forwardable'
+require 'ruby-debug'
+
+require 'open_gem/common_options'
+
+class Test_CommonOptions < Test::Unit::TestCase
+  extend Forwardable
+  
+  include OpenGem::CommonOptions
+  include Gem::VersionOption
+  
+  def_delegators :@command, :options
+  
+  def setup
+    @command = Gem::Command.new 'open'
+    @word_one = 'foo'
+    @word_two = 'bar'
+  end
+
+  def test_get_spec
+    Gem.source_index.stubs(:all_gems).returns(mock_specs_hash(test_gem))
+    
+    choices = mock_specs_hash(test_gem).values.reverse.map{ |s| "#{s.name} #{s.version}" }
+    expects(:choose_from_list).with(anything, choices).returns([choices.first, 0])
+    
+    spec_chosen = get_spec(test_gem)
+    
+    assert spec_chosen.eql?(mock_specs_hash(test_gem).values.reverse.first)
+  end
+
+  private
+  
+  def test_gem
+    "#{@word_one}_#{@word_two}"
+  end
+  
+  def gemset
+    ['', '-', '_'].map { |joiner| "#{@word_one}#{joiner}#{@word_two}" }
+  end
+  
+  def mock_specs_hash(testee)
+    @mock_specs_hash ||= gemset.inject({}) do |result, spec_name|
+      unless spec_name == testee
+        result[spec_name] = stub(
+          :name => spec_name,
+          :version => stub(:>= => true, :to_s => '0.1'),
+          :sort_obj => [spec_name, stub(:>= => true), -1]
+        )
+      end
+      result
+    end
+  end
+end


### PR DESCRIPTION
Uses a more forgiving regexp to search when GEMNAME doesn't match exactly. Specifically treats '-', '_' and '' interchangeably. Includes test.

So a 'gem open active_record' or 'gem open active-record' would successfully find 'activerecord'. Of course a 'gem open opengem' won't find 'open_gem' since it can't divine word boundaries.

Added a test in common_options_test that just tests the method changed, get_spec.
