### PR TITLE
Update Launchy dependency

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -19,7 +19,7 @@ begin
     
     # Testing
     s.test_files = FileList["test/**/*_test.rb"]
-    s.add_dependency 'launchy', '~> 0.3.5'
+    s.add_dependency 'launchy', '~> 0.4'
     s.add_development_dependency 'mocha', '~> 0.9.5'
   end
 


### PR DESCRIPTION
There is a conflict with open_gem and turbulence, because open_gem already has an older version of launchy loaded. Bumped the dependency on launchy to resolve as a stopgap.
