### PR TITLE
Require common_options directly

### DIFF
--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -5,7 +5,7 @@ require 'rubygems/dependency'
 require 'rubygems/version_option'
 
 require 'shellwords'
-require 'open_gem/common_options'
+require File.expand_path('../open_gem/common_options', __FILE__)
 
 Gem::CommandManager.instance.register_command :open
 Gem::CommandManager.instance.register_command :read


### PR DESCRIPTION
Unfortunately, it turns out that rubygems is (on my machine, at least) willing to add rake and several other gems to the LOAD_PATH while searching for `open_gem/common_options`.

As a result, simply having open_gem installed on my system at all produced load errors when I tried to require rake 0.9, since rake 0.8 had already been activated by Rubygems as a result of this require line.

If you require the file directly using the full path, as in this patch, Rubygems doesn't add anything to the LOAD_PATH, and the activation error doesn't occur.
