### PR TITLE
Fix multiple deprecation warnings in open_gem

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -1,6 +1,6 @@
 require 'rake'
 require 'rake/testtask'
-require 'rake/rdoctask'
+require 'rdoc/task'
 
 begin
   require 'jeweler'

--- a/lib/open_gem/common_options.rb
+++ b/lib/open_gem/common_options.rb
@@ -14,29 +14,16 @@ module OpenGem
       end
     end
     
-    def add_exact_match_option
-      add_option('-x', '--exact',
-                 'Only list exact matches') do |value, options|
-        options[:exact] = true
-      end
-    end
-    
     def get_spec(name)
       dep = Gem::Dependency.new(name, options[:version])
-      specs = Gem.source_index.search(dep)
+      specs = Gem::Specification.find_all_by_name(name,options[:version])
       if block_given?
         specs = specs.select{|spec| yield spec}
       end
 
       if specs.length == 0
-        # If we have not tried to do a pattern match yet, fall back on it.
-        if(!options[:exact] && !name.is_a?(Regexp))
-          pattern = /#{Regexp.escape name}/
-          get_spec(pattern)
-        else
-          say "#{name.inspect} is not available"
-          return nil
-        end
+        say "#{name.inspect} is not available"
+        return nil
 
       elsif specs.length == 1 || options[:latest]
         return specs.last

--- a/lib/rubygems/commands/open_command.rb
+++ b/lib/rubygems/commands/open_command.rb
@@ -12,7 +12,6 @@ class Gem::Commands::OpenCommand < Gem::Command
     add_command_option
     add_latest_version_option
     add_version_option
-    add_exact_match_option
   end
   
   def arguments # :nodoc:

--- a/lib/rubygems/commands/read_command.rb
+++ b/lib/rubygems/commands/read_command.rb
@@ -13,7 +13,6 @@ class Gem::Commands::ReadCommand < Gem::Command
     add_command_option "Application to read rdoc with"
     add_latest_version_option
     add_version_option
-    add_exact_match_option
   end
   
   def arguments # :nodoc:


### PR DESCRIPTION
1. `require 'rake/rdoctask'` has been deprecated in favor of 'rdoc/task'
   since RDoc 2.4.2.
2. `Gem::Dependency.new` no longer accepts a Regexp for the
   name argument. This change does not attempt to restore matching
   functionality. Correspondingly, the --exact option has been removed.
