### PR TITLE
Added "gem shell <gemname>"

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -9,6 +9,10 @@ If you just want to read documentation you can do:
 
   gem read activerecord
   
+If you just want to browse the source code in a shell you can do:
+
+  gem shell activerecord
+  
 Installation:
 ------------
 OpenGem require rubygems 1.3.6 or higher.  You may need

--- a/lib/rubygems/commands/shell_command.rb
+++ b/lib/rubygems/commands/shell_command.rb
@@ -1,0 +1,49 @@
+# ShellCommand will open a shell in a gem's dir
+class Gem::Commands::ShellCommand < Gem::Command
+  include OpenGem::CommonOptions
+  include Gem::VersionOption
+
+  def initialize
+    super 'shell', "Opens a shell in the gem's directory",
+      :command => nil,
+      :version=>  Gem::Requirement.default,
+      :latest=>   false
+
+    add_command_option
+    add_latest_version_option
+    add_version_option
+    add_exact_match_option
+  end
+
+  def arguments # :nodoc:
+    "GEMNAME       gem to read"
+  end
+
+  def execute
+    name = get_one_gem_name
+    path = get_path(name)
+
+    shell_gem(path) if path
+  end
+
+  def get_path(name)
+    if spec = get_spec(name)
+      spec.full_gem_path
+    end
+  end
+
+  def shell_gem(path)
+    shell = options[:command] || ENV['GEM_OPEN_SHELL'] || ENV['SHELL']
+    if !shell
+      say "Either set $GEM_OPEN_SHELL, $SHELL, or use -c <command_name>"
+    else
+      command_parts = Shellwords.shellwords(shell)
+      Dir.chdir(path)
+      say "Working directory is #{path} - type exit to leave"
+      success = system(*command_parts)
+      if !success
+        raise Gem::CommandLineError, "Could not run '#{shell} in #{path}', exit code: #{$?.exitstatus}"
+      end
+    end
+  end
+end

--- a/lib/rubygems_plugin.rb
+++ b/lib/rubygems_plugin.rb
@@ -9,3 +9,4 @@ require 'open_gem/common_options'
 
 Gem::CommandManager.instance.register_command :open
 Gem::CommandManager.instance.register_command :read
+Gem::CommandManager.instance.register_command :shell

--- a/open_gem.gemspec
+++ b/open_gem.gemspec
@@ -24,6 +24,7 @@ Gem::Specification.new do |s|
      "lib/open_gem/common_options.rb",
      "lib/rubygems/commands/open_command.rb",
      "lib/rubygems/commands/read_command.rb",
+     "lib/rubygems/commands/shell_command.rb",
      "lib/rubygems_plugin.rb",
      "test/open_command_test.rb"
   ]


### PR DESCRIPTION
Sometimes it's nice to browse the gem source from a shell (especially for old traditionalist vi users), to this additional plugin allows you to open a shell in the gem's path.

It's based on the open_command.rb code with almost no changes.

I originally, tried to use "gem open -c bash", but turned out to be very tricky to get working.
