### PR TITLE
Change dir for vim editor

### DIFF
--- a/lib/rubygems/commands/open_command.rb
+++ b/lib/rubygems/commands/open_command.rb
@@ -43,9 +43,11 @@ class Gem::Commands::OpenCommand < Gem::Command
     else
       command_parts = Shellwords.shellwords(editor)
       command_parts << path
-      success = system(*command_parts)
-      if !success
-        raise Gem::CommandLineError, "Could not run '#{editor} #{path}', exit code: #{$?.exitstatus}"
+      Dir.chdir(path) do
+        success = system(*command_parts)
+        if !success
+          raise Gem::CommandLineError, "Could not run '#{editor} #{path}', exit code: #{$?.exitstatus}"
+        end
       end
     end
   end


### PR DESCRIPTION
Change the working directory before opening the path helps vim editor set the current path.

Similarly to what bundler does [here](https://github.com/bundler/bundler/blob/master/lib/bundler/cli/open.rb#L16).
